### PR TITLE
Add SMILES info box and improve table spacing

### DIFF
--- a/web/frontend/src/app/components/batch-conversion/batch-conversion.component.html
+++ b/web/frontend/src/app/components/batch-conversion/batch-conversion.component.html
@@ -20,6 +20,11 @@
     multiple target types.
   </p>
 
+  <div class="info-box" role="note">
+    <mat-icon aria-hidden="true">info</mat-icon>
+    <span>SMILES conversions work when the source is InChIKey. For other sources, an InChIKey is looked up first.</span>
+  </div>
+
   <div class="batch-form" [attr.aria-busy]="loading()">
     <div class="form-left">
       <mat-form-field class="full-width">

--- a/web/frontend/src/app/components/batch-conversion/batch-conversion.component.scss
+++ b/web/frontend/src/app/components/batch-conversion/batch-conversion.component.scss
@@ -16,6 +16,21 @@
   margin-bottom: 16px;
 }
 
+.info-box {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 14px;
+  margin-bottom: 16px;
+  background: #e8f0fe;
+  border: 1px solid #b0c4de;
+  border-radius: 6px;
+  color: #1A3E68;
+  font-size: 0.9em;
+  line-height: 1.4;
+  mat-icon { flex-shrink: 0; font-size: 20px; width: 20px; height: 20px; }
+}
+
 .batch-form {
   display: flex;
   flex-wrap: wrap;

--- a/web/frontend/src/app/components/result-table/result-table.component.scss
+++ b/web/frontend/src/app/components/result-table/result-table.component.scss
@@ -1,9 +1,11 @@
-.result-table-container { overflow-x: auto; }
+.result-table-container {
+  overflow-x: auto;
+  margin-bottom: 12px;
+}
 .result-table {
   min-width: 100%;
   width: max-content;
   border-collapse: collapse;
-  margin-bottom: 16px;
   table-layout: fixed;
 }
 .result-table th, .result-table td {

--- a/web/frontend/src/app/components/single-conversion/single-conversion.component.html
+++ b/web/frontend/src/app/components/single-conversion/single-conversion.component.html
@@ -18,6 +18,11 @@
     and target types, and hit the Convert button.
   </p>
 
+  <div class="info-box" role="note">
+    <mat-icon aria-hidden="true">info</mat-icon>
+    <span>SMILES conversions work when the source is InChIKey. For other sources, an InChIKey is looked up first.</span>
+  </div>
+
   <form (ngSubmit)="convertSingle()" class="conversion-form" [attr.aria-busy]="loading()">
     <div class="form-row">
       <mat-form-field class="form-field">

--- a/web/frontend/src/app/components/single-conversion/single-conversion.component.scss
+++ b/web/frontend/src/app/components/single-conversion/single-conversion.component.scss
@@ -10,6 +10,20 @@
   gap: 8px;
   margin-bottom: 16px;
 }
+.info-box {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 14px;
+  margin-bottom: 16px;
+  background: #e8f0fe;
+  border: 1px solid #b0c4de;
+  border-radius: 6px;
+  color: #1A3E68;
+  font-size: 0.9em;
+  line-height: 1.4;
+  mat-icon { flex-shrink: 0; font-size: 20px; width: 20px; height: 20px; }
+}
 .conversion-form { margin-bottom: 24px; }
 .form-row {
   display: flex;


### PR DESCRIPTION
## Summary
- Add an info banner above the input forms on both single and batch conversion pages explaining SMILES conversion behavior
- Improve spacing between the result table and the Clear Search button / paginator

## Test plan
- [ ] Verify the info box is visible on the Single Conversion page above the form
- [ ] Verify the info box is visible on the Batch Conversion page above the form
- [ ] Verify spacing between the result table and the Clear Search button / paginator

🤖 Generated with [Claude Code](https://claude.com/claude-code)