### PR TITLE
feat: remove ChemSpider and SMILES from conversion options

### DIFF
--- a/web/frontend/src/app/services/translation.service.ts
+++ b/web/frontend/src/app/services/translation.service.ts
@@ -10,6 +10,8 @@ export interface ConversionResultItem {
 @Injectable({ providedIn: 'root' })
 export class TranslationService {
   private readonly inchikeyOnlyConversions = ['PubChem CID', 'Pubchem SID'];
+  private readonly hiddenFromValues = ['chemspider', 'smiles'];
+  private readonly hiddenToValues = ['chemspider'];
 
   private readonly additionalInChIKeyToValues: Record<string, string> = {
     'Exact Mass': 'exactmass',
@@ -21,11 +23,13 @@ export class TranslationService {
 
   async getToValues(): Promise<string[]> {
     const data = await firstValueFrom(this.http.get<string[]>('/rest/toValues'));
-    return [...data, ...this.getAdditionalInChIKeyToValues()];
+    const filtered = data.filter((v) => !this.hiddenToValues.includes(v.toLowerCase()));
+    return [...filtered, ...this.getAdditionalInChIKeyToValues()];
   }
 
   async getFromValues(): Promise<string[]> {
-    return firstValueFrom(this.http.get<string[]>('/rest/fromValues'));
+    const data = await firstValueFrom(this.http.get<string[]>('/rest/fromValues'));
+    return data.filter((v) => !this.hiddenFromValues.includes(v.toLowerCase()));
   }
 
   getAdditionalInChIKeyToValues(): string[] {

--- a/web/src/main/scala/edu/ucdavis/fiehnlab/ctsrest/web/controllers/CtsController.scala
+++ b/web/src/main/scala/edu/ucdavis/fiehnlab/ctsrest/web/controllers/CtsController.scala
@@ -6,7 +6,9 @@ import edu.ucdavis.fiehnlab.ctsrest.client.types._
 import edu.ucdavis.fiehnlab.ctsrest.web.services.SmilesConversionService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation._
+import org.springframework.web.server.ResponseStatusException
 
 
 
@@ -27,6 +29,12 @@ class CtsController extends LazyLogging {
   @Cacheable(Array("simple_convert"))
   @GetMapping(path = Array("/convert/{from}/{to}/{searchTerm}"))
   def convertSimple(@PathVariable from: String, @PathVariable to: String, @PathVariable searchTerm: String): Seq[ConversionResult] = {
+    if (from.equalsIgnoreCase("SMILES") || from.equalsIgnoreCase("ChemSpider")) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, s"Conversion from '$from' is not supported")
+    }
+    if (to.equalsIgnoreCase("ChemSpider")) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, s"Conversion to '$to' is not supported")
+    }
     if (to.equalsIgnoreCase("SMILES")) {
       convertToSmiles(from, searchTerm)
     } else {
@@ -84,13 +92,13 @@ class CtsController extends LazyLogging {
   @Cacheable(Array("from_values"))
   @GetMapping(path = Array("/fromValues"))
   def fromValues: Seq[String] = {
-    client.sourceIdNames()
+    client.sourceIdNames().filterNot(v => v.equalsIgnoreCase("Chemspider") || v.equalsIgnoreCase("SMILES"))
   }
 
   @Cacheable(Array("to_values"))
   @GetMapping(path = Array("/toValues"))
   def toValues: Seq[String] = {
-    client.targetIdNames()
+    client.targetIdNames().filterNot(_.equalsIgnoreCase("Chemspider"))
   }
 
   @Cacheable(Array("bio_count"))


### PR DESCRIPTION
## Summary
- Remove ChemSpider from both "From" and "To" conversion dropdowns
- Remove SMILES from "From" conversion dropdowns
- Block API conversions from SMILES/ChemSpider and to ChemSpider with 400 Bad Request
- Filtering applied at both backend (controller) and frontend (translation service) levels

## Test plan
- [ ] Verify ChemSpider no longer appears in "From" or "To" dropdowns (single & batch)
- [ ] Verify SMILES no longer appears in "From" dropdowns (single & batch)
- [ ] Verify direct API calls to `/rest/convert/SMILES/...` and `/rest/convert/.../ChemSpider/...` return 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)