### PR TITLE
fix accessibility: add skip-to-main link in static index.html

### DIFF
--- a/web/frontend/src/app/app.html
+++ b/web/frontend/src/app/app.html
@@ -1,6 +1,5 @@
-<a class="skip-link" href="#main-content">Skip to main content</a>
 <app-navigation></app-navigation>
-<main id="main-content" class="page-wrapper">
+<main id="main-content" class="page-wrapper" tabindex="-1">
   <div class="content-panel">
     <router-outlet></router-outlet>
   </div>

--- a/web/frontend/src/index.html
+++ b/web/frontend/src/index.html
@@ -16,6 +16,7 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
     <app-root></app-root>
   </body>
 </html>


### PR DESCRIPTION
Static scanners (SiteImprove) don't execute Angular's JS bootstrap, so the skip link inside app-root was not detected. Moved it into index.html and added tabindex=-1 to <main> so focus moves correctly on activation.